### PR TITLE
Remove 'Simple Form' example's remnant HTML

### DIFF
--- a/examples/templates/examples/dajax/full_form_example.html
+++ b/examples/templates/examples/dajax/full_form_example.html
@@ -88,7 +88,6 @@ def send_form(request, form):
 
 <h3>html</h3>
 <pre class="prettyprint language-html">
-&lt;select onchange="Dajaxice.examples.updatecombo(Dajax.process, {'option':this.value})" size="1"&gt;
 &lt;form action="" method="post" id="my_form" accept-charset="utf-8"&gt;
     &#123;&#123; form.as_p &#125;&#125;
     &lt;p&gt;&lt;input type="button" value="Send" onclick="send_form();"&gt;&lt;/p&gt;


### PR DESCRIPTION
Just a small mistake found in the 'Django Forms' example: it has remnant code from the 'Simple Form' example.
