### PR TITLE
Fix semicolon position

### DIFF
--- a/website/templates/website/base_dajaxice_example.html
+++ b/website/templates/website/base_dajaxice_example.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load url from future %}
 
-{% block extra_body %} onload="prettyPrint()"; {% endblock %}
+{% block extra_body %} onload="prettyPrint();"{% endblock %}
 
 
 {% block extra_head %}


### PR DESCRIPTION
The semicolon was out of the ending double quotation mark.
